### PR TITLE
fix createRegion reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": ">=18"
   },
   "dependencies": {
+    "fast-copy": "^3.0.1",
     "json-stable-stringify": "^1.1.0",
     "use-sync-external-store": "^1.2.0"
   },

--- a/src/createMappedRegion/index.ts
+++ b/src/createMappedRegion/index.ts
@@ -1,6 +1,7 @@
 import {useMemo, useRef} from 'react';
 import jsonStableStringify from 'json-stable-stringify';
 import {useSyncExternalStore} from 'use-sync-external-store/shim';
+import copy from 'fast-copy';
 import {deprecate} from '../util/deprecate';
 import {uniqLast, isLatest} from '../util/promiseQueue';
 import {getLocalStorageState, parseLocalStorageState, setLocalStorageState} from '../util/localStorageUtils';
@@ -246,12 +247,12 @@ function createMappedRegion <K, V>(initialValue: V | void | undefined, option?: 
     const private_getValueOrInitialValue = (key: string): V => {
         if (withLocalStorageKey) {
             const jsonString = getLocalStorageState(`${withLocalStorageKey}/${key}`);
-            const localStorageValue = parseLocalStorageState<V>(jsonString, initialValue as V);
+            const localStorageValue = parseLocalStorageState<V>(jsonString, copy(initialValue) as V);
             // 这里不 emit，所以直接操作 ref
             ref.value.set(key, localStorageValue);
             return localStorageValue;
         }
-        return initialValue as V;
+        return copy(initialValue) as V;
     };
 
     const private_getKeyString = (key: K): string => {

--- a/src/createRegion/__test__/reset.test.ts
+++ b/src/createRegion/__test__/reset.test.ts
@@ -1,0 +1,21 @@
+import createRegion from '../createRegion';
+
+describe('createRegion Reset', () => {
+    test('reset', async () => {
+        const region = createRegion<Record<string, string>>({});
+        const {set, reset, getValue} = region;
+
+        // snapshot(prevValue) is the initialvalue(same reference)
+        set(prevValue => {
+            prevValue['testKey'] = 'testValue';
+            return prevValue;
+        });
+
+        expect(getValue()).toStrictEqual({'testKey': 'testValue'});
+
+        reset();
+
+        // `set` will modify the `initialValue`, causing the `initialValue` to be not the initial value when `reset`.
+        expect(getValue()).toStrictEqual({});
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,6 +4005,11 @@ express@^4.17.3, express@^4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+fast-copy@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmmirror.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
对于一些场景，没有使用`createMappedRegion`。
在使用`createRegion`的时候，如果使用下面这个方式修改数据：
```ts
region.set(prevValue => {
    prevValue.xxx = 'xxxx';
    return prevValue;
});
```
当 region 中没有数据的时候，就会将`initialValue`赋值给`prevValue`，这样会导致`initialValue`被修改，`reset`的时候就会出问题。